### PR TITLE
fath2boinc.v: replace deprecated unix_time_milli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+fath2boinc
+pkg/

--- a/fath2boinc.v
+++ b/fath2boinc.v
@@ -92,7 +92,7 @@ fn main() {
         eprintln("USAGE: fath2boinc <local data path> <f@h data path> <boinc data path>")
         exit(1)
     }
-    now := f64(time.utc().unix_time_milli()) / 1000.0
+    now := f64(time.utc().unix_milli()) / 1000.0
 
     // F@H's bulk user statistics export only contains an username
     // which can be shared with other users. To prove ownership we


### PR DESCRIPTION
I tried compiling this just now and a deprecated function needs to be replaced for it to compile, so here's a PR for that. Included also is a `.gitignore` addition, which helps for local developments.